### PR TITLE
Removed base URL before element reference in the anchor

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -55,9 +55,9 @@
             <div class="col-md-4"></div>
             <div class="col-md-4">
               <div class="centered">
-                <a class="btn btn-outline btn" href="{{ site.baseurl }}/index.html#open-source">Open Source</a>
+                <a class="btn btn-outline btn" href="#open-source">Open Source</a>
                 &nbsp;
-                <a class="btn btn-outline btn" href="{{ site.baseurl }}/index.html#education">Education</a>
+                <a class="btn btn-outline btn" href="#education">Education</a>
               </div>
               <!-- <div class="focused-on-elem"><span class="num">1.</span> Open Source</div>
               <div class="focused-on-elem"><span class="num">2.</span> Education</div> -->


### PR DESCRIPTION
If we are at `http://scala.epfl.ch/` and we click `Open Source` button, it loads `http://scala.epfl.ch/index.html#open-source` instead of just pointing us to "Open Source" paragraph.