### PR TITLE
link to latest AB minutes

### DIFF
--- a/records.md
+++ b/records.md
@@ -9,5 +9,6 @@ layout: page
 
 ### Board meeting minutes
 
+- [November 30, 2016 - Third SC Advisory Board Meeting](https://github.com/scalacenter/advisoryboard/blob/master/minutes/003-2016-q4.md)
 - [August 9, 2016 - Second SC Advisory Board Meeting](https://github.com/scalacenter/advisoryboard/blob/master/minutes/002-2016-q3.md)
 - [May 9, 2016 - First SC Advisory Board Meeting](/minutes/2016/06/06/may-9-2016.html)


### PR DESCRIPTION
like last time, I'm linking to the GitHub repo rather than copying the content into the minutes/_posts directory 1) out of laziness, and 2) because feel weird having the same document in two locations