### PR TITLE
Scala-Native and Scala.js are not "Our Projects"

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -175,9 +175,9 @@
                           </div>
                           {% if project.logo-home %}
                           <div class="logo"><img src="{{ project.logo-home }}" alt="{{ project.name }}"></div>
-                          {% else %}
-                          <div class="text">{{ project.name }}</div>
                           {% endif %}
+                          <div class="text">{{ project.name }}</div>
+
                       </a>
                     {% endfor %}
                 </div>

--- a/_projects/10-scala-native.md
+++ b/_projects/10-scala-native.md
@@ -1,6 +1,6 @@
 ---
 label: scalaNative
-name: Scala-Native
+name: Scala-Native Support
 web:
 github: https://github.com/scalacenter/spores
 origin: SCP-001 - Native Execution of Scala/Spark via LLVM


### PR DESCRIPTION
For Scala.js we keep the text under the Logo and
For Scala-Native we show "Scala-Native Support"

/cc @sjrd ;-)