### PR TITLE
Correct typo on front page

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -108,7 +108,7 @@
         </ul>
       </div>
       <div class="col-md-12 text-left">
-        <a href="https://www.coursera.org/epfl" class="btn btn-default" target="_blank">View al courses</a>
+        <a href="https://www.coursera.org/epfl" class="btn btn-default" target="_blank">View all courses</a>
       </div>
     </div>
 


### PR DESCRIPTION
"al courses" -> "all courses"