### PR TITLE
Change homepage background colour to dark blue as text is white

### DIFF
--- a/resources/css/main.scss
+++ b/resources/css/main.scss
@@ -123,6 +123,7 @@ $fa-font-path: "./../../bower_components/font-awesome/fonts";
 
 /* HOME */
 body.home {
+  background: $dark-blue;
   .popover {
     margin-top: 25px;
     background-color: $middle-blue;


### PR DESCRIPTION
While homepage background image is loading text is not too readable due to white text on light grey background. I've added homepage css selector with dark blue background to fix that issue.

I hope it's correct repository