### PR TITLE
Fix link in 03-scala-platform-process.md

### DIFF
--- a/_projects/03-scala-platform-process.md
+++ b/_projects/03-scala-platform-process.md
@@ -13,5 +13,5 @@ description: "The Scala Platform Process provides organizational support for a b
 ---
 The Scala Platform Process provides organizational support for a broad range of open source software projects. The mission of the process is to provide high-quality software for the good of the Scala community. Through a collaborative and meritocratic development process, the Platform delivers a stable collection of libraries with widespread use and a low barrier entry for beginners and intermediate users, ready for serious production use.
 
-You can find more information on the Scala Platform [here](platform.scala-lang.org). If you would like to get involved into OSS development of the Scala Platform, let us know over [Gitter](https://gitter.im/scala/contributors).
+You can find more information on the Scala Platform [here](https://platform.scala-lang.org). If you would like to get involved into OSS development of the Scala Platform, let us know over [Gitter](https://gitter.im/scala/contributors).
 


### PR DESCRIPTION
This page produces a relative (hence broken) link to https://scala.epfl.ch/platform.scala-lang.org, as one can verify on https://scala.epfl.ch/projects.html.