### PR TITLE
Remove non-active projects from team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -26,19 +26,20 @@ layout: page
                                     {% endif %}
                                 {% else %}
                                     {% assign link = site.projects | where: "label", c | first %}
-                                    {% if link.label == 'education' %}
-                                        {% if member.member == 'julien' %}
-                                            <a href="https://www.coursera.org/learn/scala-capstone" target="_blank">
-                                                Functional Programming in Scala Capstone
-                                            </a>
-                                            {% if link.status %}<span class="status completed">Completed</span>{% endif %}
-                                        {% endif %}
-                                    {% elsif link.github %}
-                                        <a href="{{ link.github }}" target="_blank">{{ link.name }}</a> {% if link.status %}<span class="status {{ link.status | downcase }}">{{ link.status }}</span>{% endif %}
-                                    {% elsif link.web %}
-                                        <a href="{{ link.web }}" target="_blank">{{ link.name }}</a> {% if link.status %}<span class="status {{ link.status | downcase }}">{{ link.status }}</span>{% endif %}
-                                    {% else %}
-                                        <a >{{ link.name }}</a> {% if link.status %}<span class="status {{ link.status | downcase }}">{{ link.status }}</span>{% endif %}
+                                    {% if link.status == 'Active' %}
+                                      {% if link.label == 'education' %}
+                                          {% if member.member == 'julien' %}
+                                              <a href="https://www.coursera.org/learn/scala-capstone" target="_blank">
+                                                  Functional Programming in Scala Capstone
+                                              </a>
+                                          {% endif %}
+                                      {% elsif link.github %}
+                                          <a href="{{ link.github }}" target="_blank">{{ link.name }}</a>
+                                      {% elsif link.web %}
+                                          <a href="{{ link.web }}" target="_blank">{{ link.name }}</a>
+                                      {% else %}
+                                          <a >{{ link.name }}</a>
+                                      {% endif %}
                                     {% endif %}
                                 {% endif %}
                             </li>


### PR DESCRIPTION
Previously, the team page listed all projects each team member had
worked on and each project had a label "Active" "Completed"
"Contributors welcome!". After this commit we only list active projects
next to each team member and there are no more labels.

Before:

<img width="1095" alt="screen shot 2018-10-12 at 09 18 26" src="https://user-images.githubusercontent.com/1408093/46853957-d8a75680-cdff-11e8-9240-05a104a1c636.png">

After:
<img width="1082" alt="screen shot 2018-10-12 at 09 18 39" src="https://user-images.githubusercontent.com/1408093/46853971-de04a100-cdff-11e8-8cab-98f7d7d1f230.png">
