### PR TITLE
Remove Oracle from the Affiliate Members list.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -367,10 +367,12 @@
                 <a href="https://www.spotify.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/spotify.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
             <!--</div>-->
+              <!--
               <span class="subtitle col-sm-12">Affiliate members:</span>
               <div class="col-sm-12 supporter-logo">
-                <a href="https://labs.oracle.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/oracle.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <a href="https://www.example.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/example.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
+              -->
             </div>
             <div class="col-md-12 text-center">
               <span class="subtitle col-sm-12">Backer-level members:</span>


### PR DESCRIPTION
It stopped being a member a while ago.

Since it was the last Affiliate Memmber, this commit also disables the entire section. It is preserved as a generic comment for easy re-enabling in the future.