### PR TITLE
Update the project list that shows up on the front page

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -18,3 +18,7 @@ courses:
     title: Big Data Analysis with Scala and Spark
     member: heather
     taught_by: Heather Miller
+  - url: https://www.edx.org/course/programming-reactive-systems
+    label: programming-reactive-systems
+    title: Programming Reactive Systems
+    taught_by: Roland Kuhn, Konrad Malawski, and Julien Richard-Foy

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -107,9 +107,6 @@
           + an <a href="https://www.scala-exercises.org/scala_tutorial/terms_and_types">interactive introduction to Scala and FP</a> on scala-exercises.org.
         </ul>
       </div>
-      <div class="col-md-12 text-left">
-        <a href="https://www.coursera.org/epfl" class="btn btn-default" target="_blank">View all courses</a>
-      </div>
     </div>
 
     <div class="btn-blue-stripe">
@@ -159,6 +156,10 @@
               <div class="col-md-2 col-xs-4"><a href="https://www.coursera.org" target="_blank"><img width="100%" src="/resources/img/coursera@2x.png" alt="Coursera"></a></div>
             </div>
           </div>
+        </div>
+        <div class="clearfix"></div>
+        <div class="text-center" style="margin-top: 45px; clear: both;">
+          <a href="/projects.html#projects-completed" class="btn btn-default">See all the projects we’ve worked on</a>
         </div>
       </div>
     </div>

--- a/_projects/03-scala-platform-process.md
+++ b/_projects/03-scala-platform-process.md
@@ -5,10 +5,11 @@ web: https://platform.scala-lang.org
 github: https://github.com/scalacenter/platform-staging
 origin: https://github.com/scalacenter/advisoryboard/blob/master/proposals/004-sip-and-slip-coordination.md
 contributors: [jorge, guillaume]
-status: Active
+status: Aborted
 type: project
-active: true
+active: false
 home: true
+hide-from-homepage: true
 description: "The Scala Platform Process provides organizational support for a broad range of open source software projects."
 ---
 The Scala Platform Process provides organizational support for a broad range of open source software projects. The mission of the process is to provide high-quality software for the good of the Scala community. Through a collaborative and meritocratic development process, the Platform delivers a stable collection of libraries with widespread use and a low barrier entry for beginners and intermediate users, ready for serious production use.

--- a/_projects/05-education.md
+++ b/_projects/05-education.md
@@ -13,28 +13,17 @@ description: Online MOOCs and tutorials
 ---
 
 Our mission is to develop quality and widely accessible educational materials,
-and to make them freely available. We have launched 4 courses along with a
+and to make them freely available. We have launched 5 courses along with a
 capstone project. All courses can be taken for free (without a
 certificate).
 
-### Functional Programming Principles in Scala
-Course [on Coursera](https://www.coursera.org/learn/progfun1)
-and [on Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+progfun1+2018_T1/about)
-
-### Functional Program Design in Scala
-Course [on Coursera](https://www.coursera.org/learn/progfun2)
-and [on Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+progfun2+2018_T1/about)
-
-### Parallel Programming
-Course [on Coursera](https://www.coursera.org/learn/parprog1)
-and [on Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+parprog1+2018_T1/about)
-
-### Big Data Analysis with Scala and Spark
-Course [on Coursera](https://www.coursera.org/learn/scala-spark-big-data)
-and [on Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+scala-spark-big-data+2018-T1/about)
-
-### Functional Programming in Scala Capstone Project
-Course [on Coursera](https://www.coursera.org/learn/scala-capstone) only
+- [Functional Programming Principles in Scala](https://www.coursera.org/learn/progfun1)
+- [Functional Program Design in Scala](https://www.coursera.org/learn/progfun2)
+- [Parallel Programming](https://www.coursera.org/learn/parprog1)
+- [Big Data Analysis with Scala and Spark](https://www.coursera.org/learn/scala-spark-big-data)
+- [Functional Programming in Scala Capstone Project](https://www.coursera.org/learn/scala-capstone).
+- [Programming Reactive Systems](https://www.edx.org/course/programming-reactive-systems-3)
+- Effective Programming in Scala (work in progress)
 
 We have also created a [Scala Exercises](https://www.scala-exercises.org/scala_tutorial/terms_and_types)
 interactive tutorial that is based off of our above MOOCs. Walk through the

--- a/_projects/06-scalafix.md
+++ b/_projects/06-scalafix.md
@@ -9,6 +9,7 @@ status: Active
 type: project
 active: true
 home: true
+hide-from-homepage: false
 description: "Refactoring and linting tool"
 ---
 

--- a/_projects/07-scastie.md
+++ b/_projects/07-scastie.md
@@ -9,6 +9,7 @@ status: "Contributors Welcome!"
 type: project
 active: true
 home: false
+hide-from-homepage: true
 description: "Scastie can run any Scala program with any library in your browser. You don’t need to download or install anything."
 logo-home: /resources/img/scastie@2x.png
 logo: /resources/img/scastie-dark.png

--- a/_projects/08-scalajs-bundler.md
+++ b/_projects/08-scalajs-bundler.md
@@ -9,6 +9,7 @@ status: "Contributors Welcome!"
 type: project
 active: true
 home: true
+hide-from-homepage: true
 description: "Module bundler for Scala.js projects that use npm packages."
 logo-home: /resources/img/scala-js-site-logo@2x.png
 logo: /resources/img/scala-js-dark.png

--- a/_projects/09-spores-serialize-transitive-checker.md
+++ b/_projects/09-spores-serialize-transitive-checker.md
@@ -10,6 +10,7 @@ status: Completed
 type: project
 active: false
 home: false
+hide-from-homepage: true
 description: "A production-ready version of spores compatible with `{java, scala}.util.Serializable`."
 ---
 

--- a/_projects/11-collections-redesign.md
+++ b/_projects/11-collections-redesign.md
@@ -9,6 +9,7 @@ status: Completed
 type: project
 active: false
 home: false
+hide-from-homepage: true
 description: "A new collections library design for Scala 2.13."
 ---
 The Scala collections library underwent a major redesign in Scala 2.8. While the current design proved to be successful in many areas, several pain points have become apparent over the years which indicate fundamental issues with the design that cannot be removed through gradual minor changes. This prompted the request for strawman proposals for a new design in the context of Dotty. We propose that the Scala Center work on the implementation of this new design for the Scala 2.13 standard library.

--- a/_projects/12-documentation-improvements.md
+++ b/_projects/12-documentation-improvements.md
@@ -11,6 +11,7 @@ active: true
 home: false
 description: "Simplify and upgrade code examples, improve the structure and the design of the scala-lang.org website."
 ---
-[Scala tutorial based on the existing MOOCs.](https://www.scala-exercises.org/scala_tutorial/terms_and_types)
 
-[Improvements](https://github.com/scala/scala.github.com/pulls/travis032654) for [http://docs.scala-lang.org/](http://docs.scala-lang.org/)
+- [Scala tutorial based on the existing MOOCs.](https://www.scala-exercises.org/scala_tutorial/terms_and_types)
+- [Improvements](https://github.com/scala/scala.github.com/pulls/travis032654) for [http://docs.scala-lang.org/](http://docs.scala-lang.org/)
+- Review of the [Scala Book](https://docs.scala-lang.org/overviews/scala-book/introduction.html) contributed by Alvin Alexander

--- a/_projects/13-build-tools.md
+++ b/_projects/13-build-tools.md
@@ -8,6 +8,7 @@ status: Active
 type: project
 active: true
 home: false
+hide-from-homepage: true
 description: "Contributions to Zinc, Scala's incremental compiler, and sbt."
 ---
 

--- a/_projects/15-scalameta.md
+++ b/_projects/15-scalameta.md
@@ -9,6 +9,7 @@ status: Active
 type: project
 active: true
 home: false
+hide-from-homepage: true
 description: "Library to read, analyze, transform and generate Scala programs"
 ---
 

--- a/_projects/17-direct-dependency-experience.md
+++ b/_projects/17-direct-dependency-experience.md
@@ -9,6 +9,7 @@ status: Completed
 type: project
 active: false
 home: true
+hide-from-homepage: true
 description: "Improving scalac to improve the experience for builds using direct dependencies."
 ---
 

--- a/_projects/18-scalac-profiling.md
+++ b/_projects/18-scalac-profiling.md
@@ -8,7 +8,7 @@ contributors: [jvican]
 status: Completed
 type: project
 active: false
-hide-from-homepage: false
+hide-from-homepage: true
 description: "Enabling statistics in the compiler and creating the infrastructure around it."
 ---
 

--- a/_projects/19-macros.md
+++ b/_projects/19-macros.md
@@ -9,6 +9,7 @@ status: Completed
 type: project
 active: false
 home: false
+hide-from-homepage: true
 description: "Bring non-experimental and portable macros to Scala 2.x and Dotty"
 ---
 

--- a/_projects/20-bloop.md
+++ b/_projects/20-bloop.md
@@ -9,6 +9,7 @@ status: Active
 type: project
 active: true
 home: false
+hide-from-homepage: true
 description: Bloop is a command-line tool for fast edit/compile/test workflows. Its primary goal is to compile and test your project as fast as possible, offering a snappy developer experience.
 
 ---

--- a/_projects/22-coursier.md
+++ b/_projects/22-coursier.md
@@ -3,10 +3,11 @@ label: coursier
 name: coursier
 github: https://github.com/coursier/coursier
 contributors: [alexandre]
-status: Active
+status: Community Maintained
 type: project
-active: true
-home: true
+active: false
+home: false
+hide-from-homepage: true
 description: "Library and CLI to manage dependencies"
 ---
 

--- a/_projects/26-metals.md
+++ b/_projects/26-metals.md
@@ -1,0 +1,15 @@
+---
+label: metals
+name: Metals
+github: https://github.com/scalameta/metals
+contributors: [olafur]
+status: Active
+type: project
+active: true
+home: false
+hide-from-homepage: false
+description: "Scala language server with rich IDE features"
+---
+
+Scala language server with rich IDE features.
+See [project web page](https://scalameta.org/metals/).

--- a/projects.html
+++ b/projects.html
@@ -16,7 +16,7 @@ layout: page
             {% include project-block.html %}
         </div>
         {% assign projects = site.projects | where: "active", "false" %}
-        <div class="col-md-12 title completed">
+        <div class="col-md-12 title completed" id="projects-completed">
             <h2>Completed</h2>
         </div>
         <div class="project-list completed">


### PR DESCRIPTION
- Remove projects that we are not working on anymore
- Fix some content related to MOOCs

The new front page looks like this:

![Screenshot from 2020-01-20 18-12-26](https://user-images.githubusercontent.com/332812/72745632-73204900-3bb0-11ea-8947-76033890c2e0.png)
