### PR TITLE
add project priority and sort by such

### DIFF
--- a/_includes/project-block.html
+++ b/_includes/project-block.html
@@ -1,5 +1,5 @@
 
-{% assign projects_by_status = projects | sort: "priority" %}
+{% assign projects_by_status = projects | sort: "priority" | reverse %}
 {% for project in projects_by_status %}
 <div class="col-md-6">
     <div class="project" id="{{ project.label }}">

--- a/_includes/project-block.html
+++ b/_includes/project-block.html
@@ -1,5 +1,6 @@
 
-{% for project in projects %}
+{% assign projects_by_status = projects | sort: "priority" %}
+{% for project in projects_by_status %}
 <div class="col-md-6">
     <div class="project" id="{{ project.label }}">
         <div class="header" data-title="{{ project.name }}">

--- a/_projects/01-advisory-board-meeting.md
+++ b/_projects/01-advisory-board-meeting.md
@@ -8,6 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
+priority: 10
 category: process
 hide-from-homepage: true
 description: Each quarter the advisory board meets to make recommendations on the activities of the Scala Center.

--- a/_projects/01-advisory-board-meeting.md
+++ b/_projects/01-advisory-board-meeting.md
@@ -8,7 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: process
 hide-from-homepage: true
 description: Each quarter the advisory board meets to make recommendations on the activities of the Scala Center.

--- a/_projects/02-scaladex.md
+++ b/_projects/02-scaladex.md
@@ -8,7 +8,7 @@ contributors: [guillaume, julien, heather, jorge, olafur, adrien]
 status: Active
 type: project
 active: true
-priority: 1
+priority: 4
 category: tooling
 home: false
 description: "Scaladex is a catalogue of open source libraries, populated with data from GitHub and Maven Central. Projects can use SEO for more relevant results."

--- a/_projects/02-scaladex.md
+++ b/_projects/02-scaladex.md
@@ -8,6 +8,7 @@ contributors: [guillaume, julien, heather, jorge, olafur, adrien]
 status: Active
 type: project
 active: true
+priority: 1
 category: tooling
 home: false
 description: "Scaladex is a catalogue of open source libraries, populated with data from GitHub and Maven Central. Projects can use SEO for more relevant results."

--- a/_projects/03-scala-platform-process.md
+++ b/_projects/03-scala-platform-process.md
@@ -8,6 +8,7 @@ contributors: [jorge, guillaume]
 status: Aborted
 type: project
 active: false
+priority: 1000
 category: process
 home: true
 hide-from-homepage: true

--- a/_projects/03-scala-platform-process.md
+++ b/_projects/03-scala-platform-process.md
@@ -8,7 +8,7 @@ contributors: [jorge, guillaume]
 status: Aborted
 type: project
 active: false
-priority: 1000
+priority: -1
 category: process
 home: true
 hide-from-homepage: true

--- a/_projects/04-sip-process-reloaded.md
+++ b/_projects/04-sip-process-reloaded.md
@@ -8,7 +8,7 @@ contributors: [jorge, darja, sjrd]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: process
 home: true
 description: "Set of processes involving the community and aiming at improving the Scala language."

--- a/_projects/04-sip-process-reloaded.md
+++ b/_projects/04-sip-process-reloaded.md
@@ -8,6 +8,7 @@ contributors: [jorge, darja, sjrd]
 status: Active
 type: project
 active: true
+priority: 10
 category: process
 home: true
 description: "Set of processes involving the community and aiming at improving the Scala language."

--- a/_projects/05-education.md
+++ b/_projects/05-education.md
@@ -8,6 +8,7 @@ contributors: [heather, julien]
 status: Active
 type: education
 active: true
+priority: 10
 category: education
 home: false
 description: The Scala Center is responsible for many online courses that introduce the multiple styles of programming in Scala.

--- a/_projects/05-education.md
+++ b/_projects/05-education.md
@@ -8,7 +8,7 @@ contributors: [heather, julien]
 status: Active
 type: education
 active: true
-priority: 10
+priority: 1
 category: education
 home: false
 description: The Scala Center is responsible for many online courses that introduce the multiple styles of programming in Scala.

--- a/_projects/06-scalafix.md
+++ b/_projects/06-scalafix.md
@@ -8,6 +8,7 @@ contributors: [olafur]
 status: Active
 type: project
 active: true
+priority: 10
 category: tooling
 home: true
 hide-from-homepage: false

--- a/_projects/06-scalafix.md
+++ b/_projects/06-scalafix.md
@@ -8,7 +8,7 @@ contributors: [olafur]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: tooling
 home: true
 hide-from-homepage: false

--- a/_projects/07-scastie.md
+++ b/_projects/07-scastie.md
@@ -8,6 +8,7 @@ contributors: [guillaume, olafur]
 status: "Contributors Welcome!"
 type: project
 active: true
+priority: 10
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/07-scastie.md
+++ b/_projects/07-scastie.md
@@ -8,7 +8,7 @@ contributors: [guillaume, olafur]
 status: "Contributors Welcome!"
 type: project
 active: true
-priority: 10
+priority: 0
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/07-scastie.md
+++ b/_projects/07-scastie.md
@@ -8,7 +8,7 @@ contributors: [guillaume, olafur]
 status: "Contributors Welcome!"
 type: project
 active: true
-priority: 0
+priority: 8
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/08-scalajs-bundler.md
+++ b/_projects/08-scalajs-bundler.md
@@ -8,6 +8,7 @@ contributors: [julien]
 status: "Contributors Welcome!"
 type: project
 active: true
+priority: 2
 category: tooling
 home: true
 hide-from-homepage: true

--- a/_projects/09-spores-serialize-transitive-checker.md
+++ b/_projects/09-spores-serialize-transitive-checker.md
@@ -9,6 +9,7 @@ contributors: [jorge, heather, julien]
 status: Completed
 type: project
 active: false
+priority: 1000
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/09-spores-serialize-transitive-checker.md
+++ b/_projects/09-spores-serialize-transitive-checker.md
@@ -9,7 +9,7 @@ contributors: [jorge, heather, julien]
 status: Completed
 type: project
 active: false
-priority: 1000
+priority: -1
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/10-scala-native.md
+++ b/_projects/10-scala-native.md
@@ -8,7 +8,7 @@ contributors: [martinduhem, guillaume, ergys]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: enhancement
 home: true
 description: "A compiler for Scala programs producing native binaries and integrating with C."

--- a/_projects/10-scala-native.md
+++ b/_projects/10-scala-native.md
@@ -8,6 +8,7 @@ contributors: [martinduhem, guillaume, ergys]
 status: Active
 type: project
 active: true
+priority: 10
 category: enhancement
 home: true
 description: "A compiler for Scala programs producing native binaries and integrating with C."

--- a/_projects/11-collections-redesign.md
+++ b/_projects/11-collections-redesign.md
@@ -8,7 +8,7 @@ contributors: [julien]
 status: Completed
 type: project
 active: false
-priority: 1000
+priority: -1
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/11-collections-redesign.md
+++ b/_projects/11-collections-redesign.md
@@ -8,6 +8,7 @@ contributors: [julien]
 status: Completed
 type: project
 active: false
+priority: 1000
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/12-documentation-improvements.md
+++ b/_projects/12-documentation-improvements.md
@@ -8,6 +8,7 @@ contributors: [julien, jorge]
 status: "Contributors Welcome!"
 type: project
 active: true
+priority: 10
 category: enhancement
 home: false
 description: "Simplify and upgrade code examples, improve the structure and the design of the scala-lang.org website."

--- a/_projects/12-documentation-improvements.md
+++ b/_projects/12-documentation-improvements.md
@@ -8,7 +8,7 @@ contributors: [julien, jorge]
 status: "Contributors Welcome!"
 type: project
 active: true
-priority: 10
+priority: 1
 category: enhancement
 home: false
 description: "Simplify and upgrade code examples, improve the structure and the design of the scala-lang.org website."

--- a/_projects/13-build-tools.md
+++ b/_projects/13-build-tools.md
@@ -7,6 +7,7 @@ contributors: [jorge, martinduhem, olafur, jamie]
 status: Active
 type: project
 active: true
+priority: 10
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/13-build-tools.md
+++ b/_projects/13-build-tools.md
@@ -7,7 +7,7 @@ contributors: [jorge, martinduhem, olafur, jamie]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/15-scalameta.md
+++ b/_projects/15-scalameta.md
@@ -8,7 +8,7 @@ contributors: [olafur]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/15-scalameta.md
+++ b/_projects/15-scalameta.md
@@ -8,6 +8,7 @@ contributors: [olafur]
 status: Active
 type: project
 active: true
+priority: 10
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/16-dotty.md
+++ b/_projects/16-dotty.md
@@ -8,7 +8,7 @@ contributors: [olafur, jamie]
 status: "Contributors Welcome!"
 type: project
 active: true
-priority: 10
+priority: 1
 category: enhancement
 home: false
 description: "The future compiler of Scala 3.0"

--- a/_projects/16-dotty.md
+++ b/_projects/16-dotty.md
@@ -8,6 +8,7 @@ contributors: [olafur, jamie]
 status: "Contributors Welcome!"
 type: project
 active: true
+priority: 10
 category: enhancement
 home: false
 description: "The future compiler of Scala 3.0"

--- a/_projects/17-direct-dependency-experience.md
+++ b/_projects/17-direct-dependency-experience.md
@@ -8,7 +8,7 @@ contributors: [jorge]
 status: Completed
 type: project
 active: false
-priority: 1000
+priority: -1
 category: tooling
 home: true
 hide-from-homepage: true

--- a/_projects/17-direct-dependency-experience.md
+++ b/_projects/17-direct-dependency-experience.md
@@ -8,6 +8,7 @@ contributors: [jorge]
 status: Completed
 type: project
 active: false
+priority: 1000
 category: tooling
 home: true
 hide-from-homepage: true

--- a/_projects/18-scalac-profiling.md
+++ b/_projects/18-scalac-profiling.md
@@ -8,6 +8,7 @@ contributors: [jvican]
 status: Completed
 type: project
 active: false
+priority: 1000
 category: tooling
 hide-from-homepage: true
 description: "Enabling statistics in the compiler and creating the infrastructure around it."

--- a/_projects/18-scalac-profiling.md
+++ b/_projects/18-scalac-profiling.md
@@ -8,7 +8,7 @@ contributors: [jvican]
 status: Completed
 type: project
 active: false
-priority: 1000
+priority: -1
 category: tooling
 hide-from-homepage: true
 description: "Enabling statistics in the compiler and creating the infrastructure around it."

--- a/_projects/19-macros.md
+++ b/_projects/19-macros.md
@@ -8,7 +8,7 @@ contributors: [olafur]
 status: Completed
 type: project
 active: false
-priority: 1000
+priority: -1
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/19-macros.md
+++ b/_projects/19-macros.md
@@ -8,6 +8,7 @@ contributors: [olafur]
 status: Completed
 type: project
 active: false
+priority: 1000
 category: enhancement
 home: false
 hide-from-homepage: true

--- a/_projects/20-bloop.md
+++ b/_projects/20-bloop.md
@@ -8,6 +8,7 @@ contributors: [jorge, martinduhem]
 status: Active
 type: project
 active: true
+priority: 2
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/21-scalajs.md
+++ b/_projects/21-scalajs.md
@@ -8,7 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: enhancement
 home: true
 description: "Core compiler, library and tools for Scala.js."

--- a/_projects/21-scalajs.md
+++ b/_projects/21-scalajs.md
@@ -8,6 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
+priority: 10
 category: enhancement
 home: true
 description: "Core compiler, library and tools for Scala.js."

--- a/_projects/22-coursier.md
+++ b/_projects/22-coursier.md
@@ -7,7 +7,7 @@ contributors: [alexandre]
 status: Active
 type: project
 active: true
-priority: 1
+priority: 4
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/22-coursier.md
+++ b/_projects/22-coursier.md
@@ -7,6 +7,7 @@ contributors: [alexandre]
 status: Active
 type: project
 active: true
+priority: 1
 category: tooling
 home: false
 hide-from-homepage: true

--- a/_projects/23-communication.md
+++ b/_projects/23-communication.md
@@ -5,6 +5,7 @@ contributors: [darja]
 status: Active
 type: project
 active: true
+priority: 10
 home: true
 category: process
 description: "Reporting to the advisory board on Scala Center activities. Building relationships with

--- a/_projects/23-communication.md
+++ b/_projects/23-communication.md
@@ -5,7 +5,7 @@ contributors: [darja]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 home: true
 category: process
 description: "Reporting to the advisory board on Scala Center activities. Building relationships with

--- a/_projects/24-events.md
+++ b/_projects/24-events.md
@@ -7,6 +7,7 @@ web: https://scaladays.org
 github: https://github.com/scalacenter/sprees
 type: project
 active: true
+priority: 10
 category: community
 home: true
 description: "Organization of the Scala Days conference and Scala sprees."

--- a/_projects/24-events.md
+++ b/_projects/24-events.md
@@ -7,7 +7,7 @@ web: https://scaladays.org
 github: https://github.com/scalacenter/sprees
 type: project
 active: true
-priority: 10
+priority: 1
 category: community
 home: true
 description: "Organization of the Scala Days conference and Scala sprees."

--- a/_projects/25-tasty-scala-2.md
+++ b/_projects/25-tasty-scala-2.md
@@ -8,7 +8,7 @@ contributors: [jamie]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: scala3migration
 home: false
 description: Consume Scala 3 libraries from Scala 2

--- a/_projects/25-tasty-scala-2.md
+++ b/_projects/25-tasty-scala-2.md
@@ -8,6 +8,7 @@ contributors: [jamie]
 status: Active
 type: project
 active: true
+priority: 10
 category: scala3migration
 home: false
 description: Consume Scala 3 libraries from Scala 2

--- a/_projects/26-metals.md
+++ b/_projects/26-metals.md
@@ -7,6 +7,7 @@ contributors: [olafur, tgodzik, meriam]
 status: Active
 type: project
 active: true
+priority: 0
 category: tooling
 home: false
 hide-from-homepage: false

--- a/_projects/26-metals.md
+++ b/_projects/26-metals.md
@@ -7,7 +7,7 @@ contributors: [olafur, tgodzik, meriam]
 status: Active
 type: project
 active: true
-priority: 0
+priority: 8
 category: tooling
 home: false
 hide-from-homepage: false

--- a/_projects/27-trait-init-encoding.md
+++ b/_projects/27-trait-init-encoding.md
@@ -8,6 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
+priority: 10
 category: scala3migration
 home: false
 description: Reconcile the trait init encoding of Scala 3 with Scala 2

--- a/_projects/27-trait-init-encoding.md
+++ b/_projects/27-trait-init-encoding.md
@@ -8,7 +8,7 @@ contributors: [sjrd]
 status: Active
 type: project
 active: true
-priority: 10
+priority: 1
 category: scala3migration
 home: false
 description: Reconcile the trait init encoding of Scala 3 with Scala 2


### PR DESCRIPTION
prompted by @adpi2 

add a `priority` field where the ~larger~ *smaller* the number, the lower the priority. Idea being to cooperatively adjust which projects appear first.

Edit: Now a standard project has priority 1, and as that value increases it becomes more important. Completed projects use a *negative* priority. Currently I used an exponential scale but its not really important how the value grows.

The projects page is then divided by categories, but then also sorted within by the priority.

Maybe this adds maintenance overhead, but I think it is flexible

<img width="636" alt="Screenshot 2020-04-17 at 11 13 26" src="https://user-images.githubusercontent.com/13436592/79553236-78e8d600-809c-11ea-9615-d1c20f61359a.png">