### PR TITLE
Upgrade to Ruby 2.6.6 and bundler 1.17.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 language: ruby
-rvm: 2.4.4
+rvm: 2.6.6
 
 # for faster builds
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,4 +246,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.16.2
+   1.17.2


### PR DESCRIPTION
2.6.6 is the latest 2.6.x version. There is also Ruby 2.7.x, but the Windows install recommends 2.6.x at most at the moment.

@mlachkar Would you like to review this? Otherwise feel free to reassign :p