### PR TITLE
Add ids to the advisory board member lists that can be used as anchors.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -336,7 +336,7 @@
       <div class="supporters">
         <div class="container">
           <div class="row">
-            <div class="col-md-12 text-center">
+            <div class="col-md-12 text-center" id="brought-to-you-by">
               <!-- <div class="sect-header">Brought to you by</div> -->
               <h2>Brought to you by</h2>
             </div>
@@ -345,7 +345,7 @@
                <a href="http://epfl.ch" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/epfl.png" /></a>
               </div>
               <br/><br/>
-              <div class="subtitle col-sm-12">Advisory Board members:</div>
+              <div class="subtitle col-sm-12" id="advisory-board-member-list">Advisory Board members:</div>
               <div class="col-sm-3 supporter-logo">
                 <a href="http://www.goldmansachs.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/goldman.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
@@ -368,13 +368,13 @@
                 <a href="https://lunatech.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/lunatech.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
             <!--</div>-->
-              <span class="subtitle col-sm-12">Contributor members:</span>
+              <span class="subtitle col-sm-12" id="contributor-member-list">Contributor members:</span>
               <div class="col-sm-12 supporter-logo">
                 <a href="https://virtuslab.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/virtuslab.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
             <!--</div>-->
               <!--
-              <span class="subtitle col-sm-12">Affiliate members:</span>
+              <span class="subtitle col-sm-12" id="affiliate-member-list">Affiliate members:</span>
               <div class="col-sm-12 supporter-logo">
                 <a href="https://www.example.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/example.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>


### PR DESCRIPTION
With those, we can for example directly link to the list of advisory board members as
https://scala.epfl.ch/#advisory-board-member-list