### PR TITLE
remove SAP logo from front page

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -359,7 +359,7 @@
                 <a href="http://www.47deg.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/47deg.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
               <div class="col-sm-3 supporter-logo">
-                <a href="http://www.sap.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/sap.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
               </div>
               <div class="col-sm-3 supporter-logo">
                 <a href="https://www.spotify.com/" style="border: none;" target="_blank"><img src="{{ site.baseurl }}/resources/img/spotify.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
not to be merged without confirmation from @darjutak and/or @sjrd

(my understanding is that SAP is leaving the board, but has their
term actually now ended?)