### PR TITLE
Make the page on Corporate Membership much more visible.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -23,7 +23,7 @@
         <li {% if page.path == 'faqs.md' %}class="active" {% endif %}><a href="{{ site.baseurl }}/faqs.html">FAQs</a></li>
         <li {% if page.path == 'records.md' %}class="active" {% endif %}><a href="{{ site.baseurl }}/records.html">Records</a></li>
         <li {% if page.path == 'contact.md' %}class="active" {% endif %}><a href="{{ site.baseurl }}/contact.html">Contact</a></li>
-        <li {% if page.path == 'donate.md' %}class="active" {% endif %}><a href="{{ site.baseurl }}/donate.html">Donate</a></li>
+        <li {% if page.path == 'corporate-membership.md' %}class="active" {% endif %}><a href="{{ site.baseurl }}/corporate-membership.html">Corporate Membership</a></li>
         <li class="social first"><a href="https://github.com/scalacenter"><i class="fa fa-github"></i></a></li>
         <li class="social"><a href="https://twitter.com/scala_lang"><i class="fa fa-twitter"></i></a></li>
       </ul>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -25,7 +25,7 @@
                 <li><a href="{{ site.baseurl }}/faqs.html">FAQs</a></li>
                 <li><a href="{{ site.baseurl }}/records.html">Records</a></li>
                 <li><a href="{{ site.baseurl }}/contact.html">Contact</a></li>
-                <li><a href="{{ site.baseurl }}/donate.html">Donate</a></li>
+                <li><a href="{{ site.baseurl }}/corporate-membership.html">Corporate Membership</a></li>
                 <li class="social first"><a href="https://github.com/scalacenter"><i class="fa fa-github"></i></a></li>
                 <li class="social"><a href="https://twitter.com/scala_lang"><i class="fa fa-twitter"></i></a></li>
               </ul>
@@ -413,6 +413,8 @@
                   We also accept sponsorships/donations to be able to fund important project work that would otherwise not be possible.
                 </p>
                 <div class="text-center">
+                  <a class="btn btn-default btn" href="{{ site.baseurl }}/corporate-membership.html">Corporate Membership</a>
+                  <a class="btn btn-default btn" href="{{ site.baseurl }}/donate.html">Individual Donation</a>
                   <a class="btn btn-default btn" href="{{ site.baseurl }}/faqs.html">Learn More</a>
                 </div>
               </div>

--- a/corporate-membership.md
+++ b/corporate-membership.md
@@ -11,6 +11,8 @@ evaluate Scala libraries, improving the landscape of Scala's libraries, and
 coordinating and directing the development of libraries/tools of broad benefit
 to the community.
 
+(For individuals, please consider [a one-time donation](./donate.html).)
+
 ### Why join?
 
 Our main focus is to support the Scala developer community. We aim to focus on

--- a/donate.md
+++ b/donate.md
@@ -18,6 +18,8 @@ one-time donation into a monthly or yearly recurring donation. </p>
   <p id="what-happened">here</p>
 </div>
 
+(For companies, please consider [the corporate membership options](./corporate-membership.html).)
+
 ### Why contribute?
 
 Our main focus is to improve the experience of developing in Scala. This means


### PR DESCRIPTION
To put it in the top-level navbar, we sacrifice the link for individual donations, which are very rare. In exchange, we add some cross-links between the two pages.

In addition, we add two more links to the corporate membership and individual donations below the list of AB members and backer-level members.

![image](https://user-images.githubusercontent.com/535934/93883780-51003d00-fce2-11ea-8d08-1a826788e2cc.png)

![image](https://user-images.githubusercontent.com/535934/93884038-a9cfd580-fce2-11ea-8270-9a6b1366a755.png)
