### PR TITLE
fix: lock down versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM ruby:2.7
+FROM ruby:2.7.6
 
 RUN apt-get install -y curl \
   && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get install -y nodejs \
   && curl -L https://www.npmjs.com/install.sh | sh
 
-RUN gem install  bundler:1.17.2 jekyll 
+RUN gem install bundler:1.17.2 jekyll:3.9.2
 
 WORKDIR /srv/jekyll
 
 COPY Gemfile .
 COPY Gemfile.lock .
-
 
 RUN echo -n "bundle version: " && bundle --version
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y curl \
   && apt-get install -y nodejs \
   && curl -L https://www.npmjs.com/install.sh | sh
 
-RUN gem install bundler:1.17.2 jekyll:3.9.2
+RUN gem install bundler:1.17.2
 
 WORKDIR /srv/jekyll
 


### PR DESCRIPTION
Currently on a fresh install this won't work for me.
This change locks down the base image version and the
version of jekyll to match that in the lock file.
