### PR TITLE
Ruby 3.2.3 (was 3.1.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.4'
+          ruby-version: '3.2.3'
           bundler-cache: true
       - name: Bower
         run: |


### PR DESCRIPTION
context is #332 -- Fabien says our infra is on 3.2.3 now, so I think we should match that in CI
