### PR TITLE
April 2024 advisory board minutes

### DIFF
--- a/minutes/_posts/2024-04-25-april-25-2024.md
+++ b/minutes/_posts/2024-04-25-april-25-2024.md
@@ -12,7 +12,16 @@ Scala Center website.
 The following agenda was distributed to attendees:
 [agenda](https://github.com/scalacenter/advisoryboard/blob/main/agendas/032-2024-q1.md).
 
-Center activities for the past quarter focused on TODO
+We were joined by two new board members, Dmitrii Naumenko (JetBrains)
+and Zainab Ali (community representative).
+
+Center activities for the past quarter focused on pipelined
+compilation (Scala 3), TASTy Reader (Scala 2), Scala.js minifier (2
+and 3), WebAssembly backend for Scala.js (2 and 3), Metals debugger (2
+and 3), presentation compiler (3), sbt 2.x (2 and 3), the Scala
+Ambassadors initiative, Google Summer of Code, conferences (Scala.IO
+and Scalar), compiler sprees, combating Scala website scammers,
+and fundraising.
 
 Details are below and in the Center's activity report:
 
@@ -20,7 +29,9 @@ Details are below and in the Center's activity report:
 
 No new proposals were received this quarter.
 
-Other business discussed included TODO
+Other topics covered included Scala Days community discussions around
+"lean Scala" and "direct style" and related concepts, Scala LTS
+vs. Scala Next, the Scala Native 0.5 upgrade, and more.
 
 ## Date, Time and Location
 
@@ -48,7 +59,22 @@ Board members:
 * Daniela Sfregola, Morgan Stanley
 * Eugene Yokota, community representative
 
-TODO board changes?
+Apologies:
+
+* Michel Davit, Spotify
+
+## Introduction
+
+Our two new board members introduced themselves.
+
+Dmitrii Naumenko will represent JetBrains, who have just finished
+joining the board. Dmitrii is the leader of the IntelliJ Scala plugin
+team there.
+
+Zainab Ali is a new community representative, serving alongside Eugene
+Yokota. She has been organizing the London Scala Users Group for the
+last five years or so. She describes herself as a functional Scala
+developer who does training in the functional space.
 
 ## Technical report
 
@@ -62,25 +88,120 @@ And the Center's Q2 roadmap:
 
 * [roadmap](https://scala.epfl.ch/records/2024-Q2-roadmap.html)
 
-The following notes do not repeat the content of the report and
+The following notes do not repeat the contents of the report and
 roadmap, but only supplement them.
 
-TODO
+(No questions were asked about Seb's updates, so there are no further
+notes here.)
 
 ## Management and financial report
 
 Darja presented this section.
 
+In February, the Center published their [2024
+roadmap](https://www.scala-lang.org/blog/2024/02/06/scala-center-2024-roadmap.html).
+
+The Center published two blog posts about scammers targeting Scala users:
+
+* https://scala-lang.org/blog/2024/03/01/fake-scala-courses.html
+* https://www.scala-lang.org/blog/2024/03/18/scam-response.html
+
+Combating these scams consumed considerable time and effort, but the
+good news is that the scamming activity did stop.
+
+At the Scalar conference in Warsaw, the Center organized a meeting of
+conference and meetup organizers and also launched the new [Scala
+Ambassadors program](https://scala-lang.org/blog/2024/03/28/ambassadors-initiative.html).
+
+The Center's participation in Google Summer of Code for 2024 is moving
+ahead.
+
+The Center's moderation team met in person in Lausanne to share knowledge
+and experiences and to discuss and strategize.
+
+The Center's governance project made progress which Darja summarized.
+That work was eventually completed later in the year, as described
+in this October 2024 blog post:
+
+* https://www.scala-lang.org/news/new-governance.html
+
+Several engineers completed their time at the Center and moved on:
+Anatolii Kmetiuk, Jamie Thompson, and Jedrzej Rochala.  Seb will be
+teaching part-time at EPFL, so his effort level at the Center will be
+reduced to 50%.  Hiring new engineers would require new funding.
+
+The Center's 2024 roadmap reflects the smaller size of the engineering
+team. Center staff will travel less unless the travel is sponsored.
+The Center will continue to "support, empower, and amplify" active
+Scala communities and community members to accomplish things that the
+Center itself cannot.
+
+The Center continues to collect income from its MOOCs, but the amount
+continues to gradually decline.
+
+Fundraising efforts are ongoing. Multiple leads are being pursued.
+
+The effort to revive Scala Days for 2025 is ongoing. In the meantime,
+the Scala website's [events page](https://www.scala-lang.org/events/)
+is kept up to date with upcoming events.
+
 ## Scala 2 report
 
 This was presented by Lukas.
 
-TODO
+Since the last meeting, Scala 2.12.19 and 2.13.13 were released,
+and 2.13.14 is almost ready. The 2.13.14 cycle was short because
+of a few regressions. 2.13.14 introduces `-Xsource-features`.
+
+Lukas contributed an sbt PR, now merged, which aligns sbt with
+[SIP-51](https://docs.scala-lang.org/sips/drop-stdlib-forwards-bin-compat.html),
+which will allow the Scala 2.13 standard library (which is also used
+by Scala 3) to make additions again. A process for that will need
+to be set up.
 
 ## Community report
 
-TODO
+This section was led by Eugene and Zainab.
+
+They said that in the community there is a great deal of discussion,
+some confusion and uncertainty, and even some tension around the
+following complex of issues and developments: effect systems, the
+advent of Project Loom, the concept of "direct style", and Martin's
+[blog post](https://odersky.github.io/blog/2024-04-11-post.html) about
+"lean Scala". Discussion involving nearly the entire board ensued.
+
+Eugene said there was also some confusion in the community about Scala
+LTS vs Scala Next. As will be described in the next minutes, Zainab
+later submitted a proposal asking the Center to provide clearer public
+guidance on this, and that proposal was completed by the publication
+of [this new page](https://scala-lang.org/development/).
+
+Zainab praised the organizers gathering at Scalar in Warsaw in March,
+which was "useful" in strengthening networking between conference and
+meetup organizers. In London they are hoping to do even more events
+besides just talks, such as workshops, open-source sprees, and katas.
+She also expressed hope that the Center's new [Scala
+Ambassadors](https://scala-lang.org/blog/2024/03/28/ambassadors-initiative.html)
+initiative will help onboard people who want to get more involved with
+community.
+
+Zainab mentioned that pushing the Scala Native 0.4 to 0.5 upgrade
+through the open source ecosystem has been difficult. In response, Seb
+recalled when Scala.js went from 0.6 to 1.0, a transition he described
+as "difficult and long", yet necessary. Scala Native 0.4 was 3 to 4
+years ago, so the big jump to 0.5 is now "unfortunately necessary",
+but the Native team "very much hopes" that this is "the last one
+before 1.0", which is probably "a few years down the line".  Eugene
+added that setting up a Scala.js or Scala Native community build, like
+the existing JVM-centric Scala 2 and Scala 3 community builds, could
+really help (if resources could be found for such an effort). Seth
+added that library maintainers shouldn't be shy about requesting help
+from Scala Native enthusiasts, rather than feeling obligated to sort
+out problems themselves.
 
 ## Conclusion
 
-TODO
+Darja intends to organize an in-person advisory board meeting to be
+held at EPFL in the fall. Everyone on the board indicated they would
+make an effort to attend. (The in-person meeting did in fact occur, in
+September, and it will be covered in the next minutes.)

--- a/minutes/_posts/2024-04-25-april-25-2024.md
+++ b/minutes/_posts/2024-04-25-april-25-2024.md
@@ -1,0 +1,86 @@
+---
+layout: contact
+---
+
+# Minutes of the 32nd meeting of the Scala Center, Q1 2024
+
+Minutes are [archived](https://scala.epfl.ch/records.html) on the
+Scala Center website.
+
+## Summary
+
+The following agenda was distributed to attendees:
+[agenda](https://github.com/scalacenter/advisoryboard/blob/main/agendas/032-2024-q1.md).
+
+Center activities for the past quarter focused on TODO
+
+Details are below and in the Center's activity report:
+
+* [report](https://scala.epfl.ch/records/2024-Q1-activity-report.html)
+
+No new proposals were received this quarter.
+
+Other business discussed included TODO
+
+## Date, Time and Location
+
+The meeting took place virtually on Friday, April 25, 2024 at
+15:00 (UTC).
+
+Minutes were taken by Seth Tisue (secretary).
+
+## Attendees
+
+Officers:
+
+* Chris Kipp (chairperson)
+* Darja Jovanovic (executive director), EPFL
+* Sébastien Doeraene (interim technical director), EPFL
+* Martin Odersky (technical advisor), EPFL
+* Seth Tisue (secretary), Lightbend
+
+Board members:
+
+* Zainab Ali, community representative
+* Krzysztof Borowski, VirtusLab
+* Dmitrii Naumenko, JetBrains
+* Lukas Rytz, Lightbend
+* Daniela Sfregola, Morgan Stanley
+* Eugene Yokota, community representative
+
+TODO board changes?
+
+## Technical report
+
+Seb, as interim technical director, summarized Scala Center activities
+since the last meeting. His remarks were based on the Center's more
+detailed Q1 quarterly activity report:
+
+* [report](https://scala.epfl.ch/records/2024-Q1-activity-report.html)
+
+And the Center's Q2 roadmap:
+
+* [roadmap](https://scala.epfl.ch/records/2024-Q2-roadmap.html)
+
+The following notes do not repeat the content of the report and
+roadmap, but only supplement them.
+
+TODO
+
+## Management and financial report
+
+Darja presented this section.
+
+## Scala 2 report
+
+This was presented by Lukas.
+
+TODO
+
+## Community report
+
+TODO
+
+## Conclusion
+
+TODO

--- a/records.md
+++ b/records.md
@@ -40,6 +40,7 @@ in the [Projects page]({% link projects.md %}).
 
 ### Board meeting minutes
 
+- [April 25, 2024 - Thirty-Second SC Advisory Board Meeting](/minutes/2024/04/25/april-25-2024.html)
 - [February 7, 2024 - Thirty-First SC Advisory Board Meeting](/minutes/2024/02/07/february-7-2024.html)
 - [October 17, 2023 - Thirtieth SC Advisory Board Meeting](/minutes/2023/10/17/october-17-2023.html)
 - [July 26, 2023 - Twenty-Ninth SC Advisory Board Meeting](/minutes/2023/07/26/july-26-2023.html)

--- a/records/2022-Q4-activity-report.md
+++ b/records/2022-Q4-activity-report.md
@@ -207,7 +207,7 @@ In Q4, we're finally opening it to the wider public. We've integrated the projec
 
 The significance of the project is to ensure the long-term sustainability of Scala 3. Scala 3's team is smaller than corresponding teams of many other programming languages. We need to ensure that the project is not dependent on a small number of people, but rather on a large number of people who are interested in contributing to the compiler. Compiler Academy is one of the avenues that ensure a stream of new compiler enthusiasts.
 
-You can learn more about the Academy [here](https://compileracademy.carrd.co/). [Here](https://www.scala-lang.org/blog/2022/11/02/compiler-academy.html) is the blog post announcing opening it up.
+You can learn more about the Academy here (dead link: httpx://compileracademy.carrd.co/). [Here](https://www.scala-lang.org/blog/2022/11/02/compiler-academy.html) is the blog post announcing opening it up.
 
 ### Community Expansion
 

--- a/records/2023-Q1-activity-report.md
+++ b/records/2023-Q1-activity-report.md
@@ -42,8 +42,8 @@ We contributed PRs in the follow areas:
   [dotty#17088](https://github.com/lampepfl/dotty/pull/17088)
 
 Additionally, our collaborations with members of the community, either
-asynchronously or as part of the [Compiler
-Academy](https://compileracademy.carrd.co/), led to improvements
+asynchronously or as part of the Compiler
+Academy, led to improvements
 in the following areas:
 - Type inference
   [dotty#17092](https://github.com/lampepfl/dotty/pull/17092)


### PR DESCRIPTION
as usual, this is just a skeleton — the full minutes will follow once I draft them and run them by officers, then board for approval

for context, see https://contributors.scala-lang.org/t/scala-center-advisory-board-meeting-minutes/6986